### PR TITLE
SN tissue sample audit check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ foursight-smaht
 Change Log
 ----------
 
+0.8.12.b1
+=========
+* Added check to checks/audit_checks.py `check_tissue_sample_properties` that is a weekly check of GCC/TTD-submitted tissue samples to make sure they match particular metadata from corresponding TPC-submitted tissue sample item (with a matching external_id)
+* Also checks for more than one GCC/TTD-submitted tissue sample corresponding to one TPC-submitted tissue sample, as they should be one-to-one and would indicate a mislabel
+
+
 0.8.11
 ======
 * Removed tests/checks/helpers/test_wfr_utils.py (just a single import) which was causing tests to fail with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ foursight-smaht
 Change Log
 ----------
 
-0.8.12.1b1
+0.8.11.1b1
 =========
 * Added check to checks/audit_checks.py `check_tissue_sample_properties` that is a weekly check of GCC/TTD-submitted tissue samples to make sure they match particular metadata from corresponding TPC-submitted tissue sample item (with a matching external_id)
 * Also checks for more than one GCC/TTD-submitted tissue sample corresponding to one TPC-submitted tissue sample, as they should be one-to-one and would indicate a mislabel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ foursight-smaht
 Change Log
 ----------
 
-0.8.12.b1
+0.8.12.1b1
 =========
 * Added check to checks/audit_checks.py `check_tissue_sample_properties` that is a weekly check of GCC/TTD-submitted tissue samples to make sure they match particular metadata from corresponding TPC-submitted tissue sample item (with a matching external_id)
 * Also checks for more than one GCC/TTD-submitted tissue sample corresponding to one TPC-submitted tissue sample, as they should be one-to-one and would indicate a mislabel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ foursight-smaht
 Change Log
 ----------
 
-0.8.11.1b1
+0.8.12
 =========
 * Added check to checks/audit_checks.py `check_tissue_sample_properties` that is a weekly check of GCC/TTD-submitted tissue samples to make sure they match particular metadata from corresponding TPC-submitted tissue sample item (with a matching external_id)
 * Also checks for more than one GCC/TTD-submitted tissue sample corresponding to one TPC-submitted tissue sample, as they should be one-to-one and would indicate a mislabel

--- a/chalicelib_smaht/check_setup.json
+++ b/chalicelib_smaht/check_setup.json
@@ -548,5 +548,22 @@
         "display": [
             "<env-name>"
         ]
+    },
+    "check_tissue_sample_properties": {
+        "title": "Check Tissue Sample properties",
+        "group": "Audit Checks",
+        "schedule": {
+            "monday_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
     }
 }

--- a/chalicelib_smaht/checks/audit_checks.py
+++ b/chalicelib_smaht/checks/audit_checks.py
@@ -159,9 +159,11 @@ def check_tissue_sample_properties(connection, **kwargs):
         "core_size"
     ]
     incorrect = []
-    search_url = "search/?type=TissueSample&submission_centers.display_title=NDRI+TPC&limit=500"
+    search_url = "search/?type=TissueSample&submission_centers.display_title=NDRI+TPC"
     if last_mod_date:
-        search_url += '&last_modified.date_modified.from={}'.format(last_mod_date)
+        search_url += f"&last_modified.date_modified.from={last_mod_date}"
+    else:
+        search_url += "&limit=500"
     tpc_tissue_samples = ff_utils.search_metadata(search_url,key=connection.ff_keys)
     for tissue_sample in tpc_tissue_samples:
         external_id = tissue_sample['external_id']
@@ -173,7 +175,7 @@ def check_tissue_sample_properties(connection, **kwargs):
                 incorrect.append({'uuid': dup_sample['uuid'],
                     '@id': dup_sample['@id'],
                     'description': dup_sample.get('description'),
-                    'error': f"Multiple tissue sample items for one TPC-submitted tissue sample {tissue_sample.get("accession")}" })
+                    'error': f"Multiple tissue sample items for one TPC-submitted tissue sample {tissue_sample.get('accession')}"})
         for check_property in check_properties:
             if check_property in gcc_tissue_sample and check_property in tissue_sample:
                 if gcc_tissue_sample[check_property] != tissue_sample[check_property]:
@@ -181,7 +183,7 @@ def check_tissue_sample_properties(connection, **kwargs):
                         '@id': gcc_tissue_sample['@id'],
                         'description': gcc_tissue_sample.get('description'),
                         check_property: gcc_tissue_sample.get(check_property),
-                        'error': 'Inconsistent metadata properties'})
+                        'error': f"Metadata properties inconsistent with TPC-submitted tissue sample {tissue_sample.get('accession')}"})
     check.full_output = incorrect
     check.brief_output = [item['@id'] for item in incorrect]
     if incorrect:

--- a/chalicelib_smaht/checks/audit_checks.py
+++ b/chalicelib_smaht/checks/audit_checks.py
@@ -141,3 +141,48 @@ def check_for_new_submissions(connection):
                 'submission_count': current_result_count
             }
     return check
+
+
+@check_function()
+def check_tissue_sample_properties(connection, **kwargs):
+    """Weekly check of GCC-submitted tissue samples to make sure they match the metadata from corresponding TPC-submitted tissue sample item.
+    
+    """
+    check = CheckResult(connection, 'check_tissue_sample_properties')
+    check_properties = [
+        "category",
+        "sample_sources",
+        "preservation_type",
+        "core_size"
+    ]
+    incorrect = []
+    search_url = "search/?type=TissueSample&submission_centers.display_title=NDRI+TPC"
+    tpc_tissue_samples = ff_utils.search_metadata(search_url,key=connection.ff_keys)
+    for tissue_sample in tpc_tissue_samples:
+        external_id = tissue_sample['external_id']
+        gcc_search_url = f"search/?type=TissueSample&submission_centers.display_title!=NDRI+TPC&external_id={external_id}"
+        gcc_tissue_samples = ff_utils.search_metadata(gcc_search_url,key=connection.ff_keys)
+        gcc_tissue_sample = gcc_tissue_samples[0]
+        if len(gcc_tissue_samples) > 1:
+            for dup_sample in gcc_tissue_samples:
+                incorrect.append({'uuid': dup_sample['uuid'],
+                    '@id': dup_sample['@id'],
+                    'description': dup_sample.get('description'),
+                    'error': 'Multiple tissue sample items for one TPC-submitted tissue sample'})
+        for check_property in check_properties:
+            if check_property in gcc_tissue_sample and check_property in tissue_sample:
+                if gcc_tissue_sample[check_property] != tissue_sample[check_property]:
+                    incorrect.append({'uuid': gcc_tissue_sample['uuid'],
+                        '@id': gcc_tissue_sample['@id'],
+                        'description': gcc_tissue_sample.get('description'),
+                        check_property: gcc_tissue_sample.get(check_property),
+                        'error': 'Inconsistent metadata properties'})
+    check.full_output = incorrect
+    check.brief_output = [item['@id'] for item in incorrect]
+    if incorrect:
+        check.status = 'WARN'
+        check.summary = 'TissueSample found with inconsistent metadata'
+    else:
+        check.status = 'PASS'
+        check.summary = 'No tissue samples with inconsistent metadata'
+    return check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-smaht"
-version = "0.8.12.1b1"
+version = "0.8.11.1b1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-smaht"
-version = "0.8.11.1b1"
+version = "0.8.12"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-smaht"
-version = "0.8.11"
+version = "0.8.12.b1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-smaht"
-version = "0.8.12.b1"
+version = "0.8.12.1b1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Add audit check `check_tissue_sample_properties` that is a weekly check of GCC/TTD-submitted tissue samples to make sure they match particular metadata from corresponding TPC-submitted tissue sample item (with a matching `external_id`)
- Also checks for more than one GCC/TTD-submitted tissue sample corresponding to one TPC-submitted tissue sample, as they should be one-to-one and would indicate a mislabel