### PR TITLE
Check/Action to tag donors with files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ foursight-smaht
 Change Log
 ----------
 
+0.8.13
+=========
+* Added check and associated action to checks/wrangler_checks.py `untagged_donors_with_released_files` that looks for donors that have released files but are missing the 'has_released_files' tag, and adds the tag if missing.
+* NOTE: added to the Audit Check group in UI for now and scheduled to run daily in `morning_checks` schedule
+* action is initially not cued and will need to be run manually
+
+
 0.8.12
 =========
 * Added check to checks/audit_checks.py `check_tissue_sample_properties` that is a weekly check of GCC/TTD-submitted tissue samples to make sure they match particular metadata from corresponding TPC-submitted tissue sample item (with a matching external_id)

--- a/chalicelib_smaht/check_setup.json
+++ b/chalicelib_smaht/check_setup.json
@@ -565,5 +565,22 @@
         "display": [
             "<env-name>"
         ]
+    },
+        "untagged_donors_with_released_files": {
+        "title": "Check for untagged donors with released files",
+        "group": "Audit Checks",
+        "schedule": {
+            "morning_checks": {
+                "<env-name>": {
+                    "kwargs": {
+                        "primary": true
+                    },
+                    "dependencies": []
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
     }
 }

--- a/chalicelib_smaht/checks/audit_checks.py
+++ b/chalicelib_smaht/checks/audit_checks.py
@@ -87,7 +87,7 @@ def check_validation_errors(connection, **kwargs):
 
 
 @check_function()
-def check_submitted_md5(connection):
+def check_submitted_md5(connection, **kwargs):
     """ Check that any submitted md5s are consistent with the ones we generated """
     check = CheckResult(connection, 'check_submitted_md5')
 
@@ -111,7 +111,7 @@ def check_submitted_md5(connection):
 
 
 @check_function()
-def check_for_new_submissions(connection):
+def check_for_new_submissions(connection, **kwargs):
     """ Weekly check that will compare against the previous week to determine if any new submissions
         need attention
     """

--- a/chalicelib_smaht/checks/helpers/constants.py
+++ b/chalicelib_smaht/checks/helpers/constants.py
@@ -15,3 +15,10 @@ MWFR_RUNNING = "running"
 MWFR_INACTIVE = "inactive"
 MWFR_PENDING = "pending"
 MWFR_FAILED = "failed"
+
+# wrangler check constants
+RELEASED_FILE_STATUSES = [
+    'open', 'open-early', 'open-network',
+    'protected', 'protected-early', 'protected-network'
+]
+DONOR_W_FILES_TAG = "has_released_files"

--- a/chalicelib_smaht/checks/helpers/constants.py
+++ b/chalicelib_smaht/checks/helpers/constants.py
@@ -9,6 +9,7 @@ CHECK_IGNORE = "IGNORE"
 ACTION_PASS = "DONE"
 ACTION_PEND = "PEND"
 ACTION_FAIL = "FAIL"
+ACTION_WARN = "WARN"
 
 # MetaWorkflowRun final_status
 MWFR_RUNNING = "running"

--- a/chalicelib_smaht/checks/helpers/wrangler_utils.py
+++ b/chalicelib_smaht/checks/helpers/wrangler_utils.py
@@ -1,0 +1,64 @@
+import json
+from datetime import datetime
+# from dcicutils import ff_utils
+# from dcicutils.s3_utils import s3Utils
+# from packaging import version
+
+
+def item_has_property_with_value(item, property_name, property_value=None, compare_lists=False):
+    """Check if item has a specific property and, if provided, a given value.
+    - If property_value is None, just checks for existence of property.
+    - If property_value is a list and item[property_name] is a string,
+      return True if the string is in property_value.
+    - If item[property_name] is a list and property_value is a string,
+      return True if the string is in the list.
+    - If both are lists, return True if they have any value in common.
+    - If compare_lists is True, require both lists to match exactly (order-insensitive).
+    """
+    if property_value is None:
+        return property_name in item
+
+    val = item.get(property_name)
+    if val is None:
+        return False
+
+    # Normalize to lists for comparison
+    if not isinstance(property_value, list):
+        property_value = [property_value]
+    if not isinstance(val, list):
+        val = [val]
+
+    if compare_lists:
+        # Require both lists to match elements (order-insensitive)
+        return sorted(val) == sorted(property_value)
+
+    # Check if there is any overlap
+    return any(v in property_value for v in val)
+
+
+def exclude_items_with_properties(items, properties={}):
+    """Exclude items that have the given property/value info.
+    properties: dict of property_name: property_value (or list of values)
+    If property_value is None, exclude if property exists."""
+    ok_items = []
+    for item in items:
+        if not any(
+            item_has_property_with_value(item, prop, val)
+            for prop, val in properties.items()
+        ):
+            ok_items.append(item)
+    return ok_items
+
+
+def include_items_with_properties(items, properties={}):
+    """Include items that have the given property/value info.
+    properties: dict of property_name: property_value (or list of values)
+    If property_value is None, include if property exists."""
+    ok_items = []
+    for item in items:
+        if any(
+            item_has_property_with_value(item, prop, val)
+            for prop, val in properties.items()
+        ):
+            ok_items.append(item)
+    return ok_items

--- a/chalicelib_smaht/checks/wrangler_checks.py
+++ b/chalicelib_smaht/checks/wrangler_checks.py
@@ -39,8 +39,7 @@ def untagged_donors_with_released_files(connection, **kwargs):
     donors_to_tag = wr_utils.include_items_with_properties(
         wr_utils.exclude_items_with_properties(donors_with_released_files, {"tags": constants.DONOR_W_FILES_TAG}),
         {"study": "Production"})
-    donors_to_tag.extend([d.get('protected_donor') for d in donors_to_tag if
-                          ('protected_donor' in d and constants.DONOR_W_FILES_TAG not in d.get('tags', []))])
+    donors_to_tag.extend([d.get('protected_donor') for d in donors_to_tag if 'protected_donor' in d])
 
     if not donors_to_tag:
         check.allow_action = False

--- a/chalicelib_smaht/checks/wrangler_checks.py
+++ b/chalicelib_smaht/checks/wrangler_checks.py
@@ -1,14 +1,7 @@
-import re
-import requests
 import json
-import datetime
 import time
 import random
-from collections import Counter
 from dcicutils import ff_utils
-from dcicutils.env_utils import prod_bucket_env_for_app
-from foursight_core.boto_s3 import boto_s3_resource
-from foursight_core.checks.helpers import wrangler_utils
 
 # Use confchecks to import decorators object and its methods for each check module
 # rather than importing check_function, action_function, CheckResult, ActionResult
@@ -42,7 +35,6 @@ def untagged_donors_with_released_files(connection, **kwargs):
     donors_to_tag.extend([d.get('protected_donor') for d in donors_to_tag if 'protected_donor' in d])
 
     if not donors_to_tag:
-        check.allow_action = False
         check.summary = 'All donors with released files are tagged'
         check.description = f'With the tag - {constants.DONOR_W_FILES_TAG}'
         check.status = 'PASS'
@@ -134,5 +126,3 @@ def item_counts_by_type(connection, **kwargs):
         check.summary = check.description = 'DB and ES item counts are equal'
     check.full_output = item_counts
     return check
-
-


### PR DESCRIPTION
- checks for Donors that have files with network viewable or above statuses and do not have the tag 'has_released_files' 
- associated action adds the tag to the Donor and ProtectedDonor items
- check schedule daily in morning_checks