### PR TITLE
Increase check limits for lifecycle checks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ foursight-smaht
 Change Log
 ----------
 
+0.8.18
+======
+* Increase limits of lifecycle status checks.
+
+
 0.8.17
 ======
 * Update the sample_consistency_check to ensure that all GCC samples have a corresponding TPC sample with matching external_id.

--- a/chalicelib_smaht/check_setup.json
+++ b/chalicelib_smaht/check_setup.json
@@ -382,7 +382,7 @@
             "hourly_checks": {
                 "<env-name>": {
                     "kwargs": {
-                        "files_per_run": 100,
+                        "files_per_run": 500,
                         "max_checking_frequency": 14,
                         "first_check_after": 14,
                         "queue_action": "prod"
@@ -402,7 +402,7 @@
             "hourly_checks": {
                 "<env-name>": {
                     "kwargs": {
-                        "files_per_run": 50,
+                        "files_per_run": 100,
                         "check_after": 14,
                         "queue_action": "prod"
                     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-smaht"
-version = "0.8.17"
+version = "0.8.18"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
The checks can't keep up with the amount of data we are currently processing. Therefore increase the lifecycle check limits.