### PR TITLE
migrate all workflows to OIDC auth

### DIFF
--- a/.github/workflows/main-CI.yml
+++ b/.github/workflows/main-CI.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: #Needed for OIDC authentication
+  id-token: write
+  contents: read        
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -32,10 +35,9 @@ jobs:
         run: pip install poetry
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: QA

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: #Needed for OIDC authentication
+  id-token: write
+  contents: read    
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -26,10 +29,9 @@ jobs:
         run: make build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Deploy


### PR DESCRIPTION
Summary
Replaces static AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY GitHub secrets
with OIDC role assumption across all workflows. This is more secure
as it eliminates long-lived AWS credentials stored as GitHub secrets.

Changes
main-CI.yml & main-deploy.yml — switched to OIDC auth, bumped configure-aws-credentials v1 → v4 (required for OIDC), added permissions: id-token: write block (required for GitHub to issue OIDC token)
Testing
✅ CI passed on this branch
✅ AWS credentials step passes with OIDC role assumption confirmed
After this is merged
The following repo secrets can be deleted by an admin if not used in other areas of the pipeline:

AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_OIDC_ROLE_ARN must remain.