### PR TITLE
260616 ajs tpc to gcc sample transfer metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ foursight-smaht
 Change Log
 ----------
 
+0.9.2
+======
+* Add new check and action to transfer some properties from TPC-submitted tissue samples to matching GCC/TTD-submitted tissue samples (matched by external_id) and add a tag to indicate the sync has been done.
+
+
 0.9.1
 ======
 * Add publication fetch check to check_setup.json - with manual 'schedule'

--- a/chalicelib_smaht/check_setup.json
+++ b/chalicelib_smaht/check_setup.json
@@ -566,6 +566,22 @@
             "<env-name>"
         ]
     },
+    "sync_tpc_tissue_sample_metadata": {
+        "title": "Sync TPC metadata to non-TPC tissue samples",
+        "group": "Audit Checks",
+        "schedule": {
+            "manual_checks": {
+                "all": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        },
+        "display": [
+            "<env-name>"
+        ]
+    },
     "untagged_donors_with_released_files": {
         "title": "Check for untagged donors with released files",
         "group": "Audit Checks",

--- a/chalicelib_smaht/checks/helpers/constants.py
+++ b/chalicelib_smaht/checks/helpers/constants.py
@@ -25,6 +25,7 @@ RELEASED_FILE_STATUSES = [
 DONOR_W_FILES_TAG = "has_released_files"
 TPC_NAME = "NDRI TPC"
 DAC_NAME = "HMS DAC"
+TPC_METADATA_SYNCED_TAG = "tpc_metadata_synced"
 
 # constants for external resource retrieval
 CROSSREF_API = "https://api.crossref.org/works/"

--- a/chalicelib_smaht/checks/wrangler_checks.py
+++ b/chalicelib_smaht/checks/wrangler_checks.py
@@ -1064,7 +1064,7 @@ def _build_tpc_field_patch(tpc_sample, target_sample):
     return patch or None
 
 
-@check_function(action="patch_tpc_tissue_sample_metadata", samples_per_run=200)
+@check_function(action="patch_tpc_tissue_sample_metadata", samples_per_run=1000)
 def sync_tpc_tissue_sample_metadata(connection, **kwargs):
     """Find non-TPC tissue samples that need metadata synced from their matching TPC
     sample (matched by external_id) and have not yet been processed (no

--- a/chalicelib_smaht/checks/wrangler_checks.py
+++ b/chalicelib_smaht/checks/wrangler_checks.py
@@ -1031,3 +1031,137 @@ def update_pub_metadata(connection, **kwargs):
 
     action.output = action_logs
     return action
+
+
+# ---------------------------------------------------------------------------
+# TPC → non-TPC tissue sample metadata sync
+# ---------------------------------------------------------------------------
+
+def _get_tpc_sample(external_id, ff_keys):
+    """Return the TPC tissue_sample matching external_id, or None."""
+    results = ff_utils.search_metadata(
+        f"search/?type=TissueSample"
+        f"&external_id={external_id}"
+        f"&submission_centers.display_title={constants.TPC_NAME.replace(' ', '+')}"
+        f"&status!=deleted",
+        key=ff_keys,
+    )
+    return results[0] if results else None
+
+
+def _build_tpc_field_patch(tpc_sample, target_sample):
+    """Return field-only patch dict (no tags), or None if nothing to transfer."""
+    patch = {}
+    if tpc_sample.get("preservation_type") and not target_sample.get("preservation_type"):
+        patch["preservation_type"] = tpc_sample["preservation_type"]
+    for field in ("description", "processing_notes"):
+        tpc_val = tpc_sample.get(field)
+        target_val = target_sample.get(field)
+        if tpc_val and target_val:
+            patch[field] = f"GCC: {target_val}; TPC: {tpc_val}"
+        elif tpc_val:
+            patch[field] = f"TPC: {tpc_val}"
+    return patch or None
+
+
+@check_function(action="patch_tpc_tissue_sample_metadata", samples_per_run=200)
+def sync_tpc_tissue_sample_metadata(connection, **kwargs):
+    """Find non-TPC tissue samples that need metadata synced from their matching TPC
+    sample (matched by external_id) and have not yet been processed (no
+    tpc_metadata_synced tag).  Runs up to samples_per_run lookups per invocation to
+    stay within Lambda timeout."""
+    check = CheckResult(connection, "sync_tpc_tissue_sample_metadata")
+    check.action = "patch_tpc_tissue_sample_metadata"
+    check.allow_action = False
+    wait = round(random.uniform(0.1, random_wait), 1)
+    time.sleep(wait)
+
+    samples_per_run = kwargs.get("samples_per_run", 200)
+    query = (
+        f"search/?type=TissueSample"
+        f"&submission_centers.display_title!={constants.TPC_NAME.replace(' ', '+')}"
+        f"&tags!={constants.TPC_METADATA_SYNCED_TAG}"
+        f"&status!=deleted"
+        f"&limit={samples_per_run}"
+    )
+    candidates = ff_utils.search_metadata(query, key=connection.ff_keys)
+
+    to_patch = []
+    for sample in candidates:
+        external_id = sample.get("external_id")
+        if not external_id:
+            continue
+        tpc_sample = _get_tpc_sample(external_id, connection.ff_keys)
+        if not tpc_sample:
+            continue
+        field_patch = _build_tpc_field_patch(tpc_sample, sample)
+        to_patch.append({
+            "uuid": sample["uuid"],
+            "external_id": external_id,
+            "patch": field_patch or {},
+        })
+
+    if not to_patch:
+        check.status = constants.CHECK_PASS
+        check.summary = "All non-TPC tissue samples have been synced with TPC metadata"
+        return check
+
+    check.status = constants.CHECK_WARN
+    check.allow_action = True
+    check.summary = f"{len(to_patch)} non-TPC tissue sample(s) need TPC metadata synced"
+    check.brief_output = f"{len(to_patch)} samples to patch (batch size: {samples_per_run})"
+    check.full_output = {"to_patch": to_patch}
+    return check
+
+
+@action_function()
+def patch_tpc_tissue_sample_metadata(connection, **kwargs):
+    """Apply TPC metadata (preservation_type, description, processing_notes) to
+    non-TPC tissue samples identified by sync_tpc_tissue_sample_metadata, and mark
+    each with the tpc_metadata_synced tag."""
+    action = ActionResult(connection, "patch_tpc_tissue_sample_metadata")
+    action_logs = {"patch_success": [], "patch_failure": []}
+
+    check_result = action.get_associated_check_result(kwargs)
+    to_patch = check_result.get("full_output", {}).get("to_patch", [])
+
+    for item in to_patch:
+        uuid = item.get("uuid")
+        external_id = item.get("external_id", uuid)
+        field_patch = item.get("patch", {})
+        try:
+            existing_tags = ff_utils.get_metadata(
+                uuid, key=connection.ff_keys
+            ).get("tags", [])
+        except Exception as e:
+            action.status = constants.ACTION_WARN
+            action_logs["patch_failure"].append(
+                f"Error fetching tags for {uuid} (external_id: {external_id}): {e}"
+            )
+            continue
+
+        patch_body = {
+            **field_patch,
+            "tags": list(set(existing_tags + [constants.TPC_METADATA_SYNCED_TAG])),
+        }
+        try:
+            ff_utils.patch_metadata(patch_body, obj_id=uuid, key=connection.ff_keys)
+            action_logs["patch_success"].append(
+                f"Patched {uuid} (external_id: {external_id}): {list(patch_body.keys())}"
+            )
+        except Exception as e:
+            action.status = constants.ACTION_WARN
+            action_logs["patch_failure"].append(
+                f"Error patching {uuid} (external_id: {external_id}): {e}"
+            )
+
+    if not action_logs["patch_failure"] and len(action_logs["patch_success"]) == len(to_patch):
+        action.status = constants.ACTION_PASS
+        action.summary = f"Successfully synced TPC metadata for {len(to_patch)} tissue sample(s)"
+    else:
+        action.summary = (
+            f"{len(action_logs['patch_success'])} succeeded, "
+            f"{len(action_logs['patch_failure'])} failed"
+        )
+    action.output = action_logs
+    return action

--- a/chalicelib_smaht/checks/wrangler_checks.py
+++ b/chalicelib_smaht/checks/wrangler_checks.py
@@ -1081,7 +1081,7 @@ def sync_tpc_tissue_sample_metadata(connection, **kwargs):
         f"search/?type=TissueSample"
         f"&submission_centers.display_title!={constants.TPC_NAME.replace(' ', '+')}"
         f"&tags!={constants.TPC_METADATA_SYNCED_TAG}"
-        f"&status!=deleted"
+        f"&status=open&status=open-early"
         f"&limit={samples_per_run}"
     )
     candidates = ff_utils.search_metadata(query, key=connection.ff_keys)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight-smaht"
-version = "0.9.1"
+version = "0.9.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Check and action that will:

Search for released GCC tissue_samples that have not been tagged as have already been processed by this check/action
and determine how to patch to transfer metadata fields from the corresponding TPC sample (shared external_id).

Fields that are transferred are:
preservation_type (not generally submitted by GCCs)
description (submitted rarely by GCC)
processing_notes (submitted rarely by GCC)

For the latter 2 cases the transferred value has TPC: prepended and any existing value gets GCC: prepended and the values become a concatenation of the 2 strings.

Currently on a daily check schedule with the action not auto queued until we are convinced everything works as expected.